### PR TITLE
Disallow creating different slugs with similar URLs

### DIFF
--- a/app/models/redirection.rb
+++ b/app/models/redirection.rb
@@ -5,6 +5,7 @@ class Redirection < ActiveRecord::Base
   validates :next_id, uniqueness: true
   validates :slug, presence: true, uniqueness: true
   validates :url, presence: true
+  validate :unique_url_ignoring_www_and_protocol
 
   scope :in_ring_order, -> { order(next_id: :desc) }
   scope :latest_first, -> { order(created_at: :desc) }
@@ -34,6 +35,25 @@ class Redirection < ActiveRecord::Base
     self.class.transaction do
       destroy!
       previous_redirection.update!(next: next_redirection)
+    end
+  end
+
+  private
+
+  def unique_url_ignoring_www_and_protocol
+    if url.present?
+      uri = URI.parse(url)
+      normalized_uri = "#{uri.host.sub(/^www./, '')}#{uri.path}?#{uri.query}"
+      matching_redirection = Redirection.where.not(slug: slug).all.detect do |redirection|
+        other_uri = URI.parse(redirection.url)
+        other_normalized_uri = other_uri.host.sub(/^www./, '') +
+          other_uri.path +
+          "?#{other_uri.query}"
+        other_normalized_uri == normalized_uri
+      end
+      if matching_redirection
+        errors.add(:url, "is already taken by #{matching_redirection.slug}")
+      end
     end
   end
 end

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -1,5 +1,19 @@
 require "rails_helper"
 
+RSpec.shared_examples_for "disallowing a similar URL" do |action, item|
+  it "does not add #{item[:new]} when #{item[:existing]} already exists" do
+    old_slug = "old"
+    new_slug = "new"
+    RedirectionCreation.perform(item[:existing], old_slug)
+
+    request.env["HTTP_REFERER"] = item[:new]
+    expect {
+      get action, params: { slug: new_slug }
+    }.to raise_error(ActiveRecord::RecordInvalid)
+    expect(Redirection.where(slug: new_slug)).to be_empty
+  end
+end
+
 RSpec.describe RedirectionsController do
   describe "GET :next" do
     it "redirects to the next site" do
@@ -26,6 +40,40 @@ RSpec.describe RedirectionsController do
         new_redirection = Redirection.last
         expect(new_redirection.slug).to eq new_slug
         expect(first_redirection.reload.next).to eq new_redirection
+      end
+
+      it "does not allow creating the exact same URL twice" do
+        url = "https://unique-website.com"
+        new_slug = "new"
+        old_slug = "old"
+        RedirectionCreation.perform(url, old_slug)
+
+        request.env["HTTP_REFERER"] = url
+        expect {
+          get action, params: { slug: new_slug }
+        }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(Redirection.where(slug: new_slug)).to be_empty
+      end
+
+      describe "consider WWW vs non-WWW the same" do
+        www_vs_not = [
+          { existing: "https://www.cool.com", new: "https://cool.com" },
+          { existing: "http://www.foo.com", new: "https://foo.com" },
+        ]
+        www_vs_not.each do |item|
+          it_should_behave_like "disallowing a similar URL", action, item
+        end
+      end
+
+      describe "consider HTTP/HTTPS the same" do
+        http_vs_https = [
+          { existing: "http://foo.com", new: "https://www.foo.com" },
+          { existing: "https://foo.com", new: "http://foo.com" },
+        ]
+        http_vs_https.each do |item|
+          it_should_behave_like "disallowing a similar URL", action, item
+        end
       end
 
       it "ignores requests from http://localhost" do

--- a/spec/models/redirection_spec.rb
+++ b/spec/models/redirection_spec.rb
@@ -20,6 +20,34 @@ RSpec.describe Redirection do
       it { should validate_uniqueness_of :next_id }
       it { should validate_uniqueness_of :slug }
     end
+
+    it "ignores `www` subdomain when comparing URLs for uniqueness" do
+      old_slug = "old"
+      old_url = "http://foo.com"
+      new_url = "https://www.foo.com"
+      RedirectionCreation.perform(old_url, old_slug)
+
+      redirection = Redirection.new(url: new_url)
+      redirection.validate
+
+      expect(redirection.errors[:url]).to include(
+        "is already taken by #{old_slug}"
+      )
+    end
+
+    it "ignores protocol when comparing URLs for uniqueness" do
+      old_slug = "old"
+      old_url = "http://www.foo.com"
+      new_url = "https://www.foo.com"
+      RedirectionCreation.perform(old_url, old_slug)
+
+      redirection = Redirection.new(url: new_url)
+      redirection.validate
+
+      expect(redirection.errors[:url]).to include(
+        "is already taken by #{old_slug}"
+      )
+    end
   end
 
   describe ".in_ring_order" do


### PR DESCRIPTION
When creating a new Redirection, this will normalize the URL by removing the protocol (HTTP/S) and any `www.` subdomain. So this:

```
https://www.foo.com/something?else=1
```

becomes this:

```
foo.com/something?else=1
```

Then we compare that normalized URL against the normalized URL of every other redirection, and mark the new record as invalid if there's a match.

-------------

This was prompted by a Redirection being added for `http://hotlinewebring.club`
when HLWR itself has `https://hotlinewebring.club`.

My big concern is:

* Running Ruby code every time we touch a Redirection is inefficient. Should we store the normalized URL in a field on the Redirection and re-calculate it whenever it's created/updated? Does it matter, given the number of records we're talking about?