### PR TITLE
Make the link audit task more resilient

### DIFF
--- a/app/models/missing_link_finder.rb
+++ b/app/models/missing_link_finder.rb
@@ -10,8 +10,30 @@ class MissingLinkFinder
   end
 
   def run
-    html = fetch(redirection.url)
+    begin
+      response = fetch(redirection.url)
+      if response.is_a?(Net::HTTPSuccess)
+        missing = missing_links(response.body)
+        if missing.empty?
+          { status: :good }
+        else
+          { status: :missing_links, missing: missing }
+        end
+      else
+        { status: :offline }
+      end
+    rescue SocketError
+      { status: :offline }
+    rescue StandardError => error
+      { status: :error, error: "#{error.class}: #{error.message}" }
+    end
+  end
 
+  private
+
+  attr_reader :redirection
+
+  def missing_links(html)
     if html
       missing_links = []
       missing_links << "next" if !html.match?(next_link)
@@ -20,10 +42,6 @@ class MissingLinkFinder
       missing_links
     end
   end
-
-  private
-
-  attr_reader :redirection
 
   def next_link
     /#{HOST}#{SLASH}#{redirection.slug}#{SLASH}next/
@@ -35,16 +53,12 @@ class MissingLinkFinder
 
   def fetch(url_string)
     url = URI(url_string)
-    begin
-      response = Net::HTTP.get_response(url)
-      case response
-      when Net::HTTPSuccess
-        response.body
-      when Net::HTTPRedirection
-        fetch(response["location"])
-      end
-    rescue SocketError
-      nil
+    response = Net::HTTP.get_response(url)
+    case response
+    when Net::HTTPRedirection
+      fetch(response["location"])
+    else
+      response
     end
   end
 end

--- a/lib/tasks/link-audit.rake
+++ b/lib/tasks/link-audit.rake
@@ -9,14 +9,16 @@ task link_audit: :environment do
   end
 
   Redirection.find_each do |redirection|
-    missing_links = MissingLinkFinder.new(redirection).run
+    result = MissingLinkFinder.new(redirection).run
 
-    if missing_links.nil?
-      red("#{redirection.url} is no longer online at all")
-    elsif missing_links.empty?
+    if result[:status] == :good
       green("#{redirection.url} is all good")
-    else
-      red("#{redirection.url} is missing #{missing_links.join(' and ')}")
+    elsif result[:status] == :offline
+      red("#{redirection.url} is no longer online at all")
+    elsif result[:status] == :error
+      red("#{redirection.url} error: #{result[:error]} ")
+    elsif result[:status] == :missing_links
+      red("#{redirection.url} is missing #{result[:missing].join(' and ')}")
     end
   end
 end


### PR DESCRIPTION
* Just like before, if there's a `SocketError`, indicate that the website is completely offline
* If there is any other kind of error (`StandardError`), print the error message

The certificate for https://irongeek.net expired and the `rake link_audit` task crashed when it got to it. Now it prints the error and keeps going.

To accommodate showing more information, the `MissingLinkFinder` now sends more information back to the link audit task, including a `status` plus information relating to that status.

<img width="1131" alt="Alacritty 2020-06-05 20-15-09" src="https://user-images.githubusercontent.com/257678/83935334-94ec2800-a76d-11ea-975f-5299cf16d3a7.png">
