### PR TITLE
Use newer Spring binstubs to avoid warning

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 require 'bundler/setup'
 load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,15 +1,17 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast.
+# This file loads Spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
-  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { "GEM_PATH" => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem "spring", match[1]
-    require "spring/binstub"
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
   end
 end


### PR DESCRIPTION
`bin/spring` was using `Gem.paths=` which printed this warning whenever `bin/rspec` (which uses Spring) ran:

>Array values in the parameter to `Gem.paths=` are deprecated.

Now it uses different code and does not print a warning.