### PR TITLE
Make capybara-mechanize available in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.7.1"
 
 gem "autoprefixer-rails"
 gem "bourbon", "~> 4.2.0"
+gem "capybara-mechanize"
 gem "flutie"
 gem "high_voltage"
 gem "neat", "~> 1.7.0"
@@ -36,7 +37,6 @@ end
 
 group :test do
   gem "capybara", "~> 3.0"
-  gem "capybara-mechanize"
   gem "launchy"
   gem "rspec_junit_formatter"
   gem "shoulda-matchers"

--- a/app/models/missing_link_finder.rb
+++ b/app/models/missing_link_finder.rb
@@ -21,10 +21,11 @@ class MissingLinkFinder
   def run
     session.visit(redirection.url)
     if session.status_code.in?(200..299)
-      if missing_links.empty?
+      missing = missing_links
+      if missing.empty?
         {status: :good}
       else
-        {status: :missing_links, missing: missing_links}
+        {status: :missing_links, missing: missing}
       end
     else
       {status: :offline}


### PR DESCRIPTION
It broke the whole website (now rolled back) because we try to load capybara-mechanize when we preload all the classes.

I tested this branch on staging, so it definitely works now.