### PR TITLE
Use the full original referrer, not the hostname

### DIFF
--- a/app/services/redirection_creation.rb
+++ b/app/services/redirection_creation.rb
@@ -13,7 +13,7 @@ class RedirectionCreation
 
     if referrer.present?
       redirection.original_url = referrer
-      redirection.url = referrer_hostname
+      redirection.url = referrer
       Ring.new(redirection).link
       redirection
     end
@@ -22,9 +22,4 @@ class RedirectionCreation
   private
 
   attr_reader :referrer, :slug
-
-  def referrer_hostname
-    referrer_uri = URI.parse(referrer)
-    "#{referrer_uri.scheme}://#{referrer_uri.hostname}"
-  end
 end

--- a/spec/services/redirection_creation_spec.rb
+++ b/spec/services/redirection_creation_spec.rb
@@ -2,17 +2,15 @@ require "rails_helper"
 
 RSpec.describe RedirectionCreation do
   context "when the referrer is present" do
-    it "creates a redirection with the referrer hostname" do
+    it "creates a redirection with the full referrer" do
       referrer_hostname = "https://cool.example.com"
+      full_referrer = "#{referrer_hostname}/something/else"
       slug = "cool-slug"
 
-      RedirectionCreation.perform(
-        "#{referrer_hostname}/something",
-        slug,
-      )
+      RedirectionCreation.perform(full_referrer, slug)
 
       redirection = Redirection.find_by!(slug: slug)
-      expect(redirection.url).to eq referrer_hostname
+      expect(redirection.url).to eq full_referrer
     end
 
     it "stores the original unchanged referrer" do
@@ -32,7 +30,7 @@ RSpec.describe RedirectionCreation do
 
       redirection = RedirectionCreation.perform(
         "http://example.com",
-        "slug",
+        "slug"
       )
 
       expect(redirection.previous).to eq first_redirection


### PR DESCRIPTION
90% of the time, this is what we want anyway.

We still store the full referrer as `original_url` just in case we change the `url` again later.