### PR TITLE
Limit blocks so they don't affect the whole domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
         environment:
           POSTGRES_USER: hotlinewebring
           POSTGRES_DB: hotlinewebring_test
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: password
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           RAILS_ENV: test
           PGHOST: localhost
           PGUSER: hotlinewebring
-      - image: circleci/postgres:10.6
+      - image: circleci/postgres:13.3-ram
         environment:
           POSTGRES_USER: hotlinewebring
           POSTGRES_DB: hotlinewebring_test

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -7,10 +7,11 @@ class Block
     if possible_match.nil?
       false
     else
-      host = URI.parse(possible_match).host
+      uri = URI.parse(possible_match)
+      host_with_path = "#{uri.host}#{uri.path}"
 
-      BlockedReferrer.where("host_with_path LIKE ?", "#{host}%").
-        or(BlockedReferrer.where("'www.'||host_with_path LIKE ?", "#{host}%")).
+      BlockedReferrer.where("starts_with(lower(?), lower(host_with_path))", host_with_path).
+        or(BlockedReferrer.where("starts_with(lower(?), lower('www.'||host_with_path))", host_with_path)).
         any?
     end
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,6 +11,7 @@ development: &default
 test:
   <<: *default
   database: hotline-webring_test
+  password: password
 
 production: &deploy
   encoding: utf8

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Block do
         expect(Block.new(url)).to be_blocked
       end
 
+      it "is case-insensitive" do
+        url = "https://www.EVIL.com/ANYthing/goes/here"
+        expect(Block.new(url)).to be_blocked
+      end
+
       it "does not match a subdomain that isn't 'www'" do
         url = "https://good.evil.com"
         expect(Block.new(url)).not_to be_blocked
@@ -39,6 +44,41 @@ RSpec.describe Block do
 
       it "does not match a different domain" do
         url = "https://good.com/"
+        expect(Block.new(url)).not_to be_blocked
+      end
+
+      it "does not match when the given URL contains a prefix of the blocked URL" do
+        url = "http://www.not-evil.com"
+        expect(Block.new(url)).not_to be_blocked
+      end
+
+      it "never matches nil" do
+        expect(Block.new(nil)).not_to be_blocked
+      end
+    end
+
+    context 'blocking evil.com/subpath' do
+      before do
+        create(:blocked_referrer, host_with_path: "evil.com/subpath")
+      end
+
+      it "matches the URL exactly" do
+        url = "https://www.evil.com/subpath"
+        expect(Block.new(url)).to be_blocked
+      end
+
+      it "matches any path under the URL" do
+        url = "https://www.evil.com/subpath/sub-subpath"
+        expect(Block.new(url)).to be_blocked
+      end
+
+      it "does not match a parent path" do
+        url = "http://www.evil.com"
+        expect(Block.new(url)).not_to be_blocked
+      end
+
+      it "does not match when the given URL contains a prefix of the blocked URL" do
+        url = "http://www.not-evil.com/subpath"
         expect(Block.new(url)).not_to be_blocked
       end
 


### PR DESCRIPTION
Previously, when blocking `evil.com/subpath`, it would block all of `evil.com`, because our SQL condition was switched.

It was also not case-insensitive.

This fixes both issues, and adds tests.