### PR TITLE
Correctly match blocked referrer paths

### DIFF
--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -7,16 +7,28 @@ class Block
     if possible_match.nil?
       false
     else
-      uri = URI.parse(possible_match)
-      host_with_path = "#{uri.host}#{uri.path}"
+      uri = URI.parse(possible_match.downcase)
 
-      BlockedReferrer.where("starts_with(lower(?), lower(host_with_path))", host_with_path).
-        or(BlockedReferrer.where("starts_with(lower(?), lower('www.'||host_with_path))", host_with_path)).
-        any?
+      BlockedReferrer.pluck(:host_with_path).any? do |blocked_host_with_path|
+        blocked_uri = URI.parse("http://" + blocked_host_with_path.downcase)
+
+        hosts_match?(uri, blocked_uri) && paths_match?(uri, blocked_uri)
+      end
     end
   end
 
   private
 
   attr_reader :possible_match
+
+  def hosts_match?(uri, blocked_uri)
+    uri.host == blocked_uri.host || uri.host == "www.#{blocked_uri.host}"
+  end
+
+  def paths_match?(uri, blocked_uri)
+    blocked_path = blocked_uri.path
+    blocked_path == "" ||
+      uri.path == blocked_path ||
+      Pathname.new(uri.path).ascend.include?(Pathname.new(blocked_path))
+  end
 end

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe Block do
         expect(Block.new(url)).to be_blocked
       end
 
+      it "does not match a path that is a prefix of the blocked path" do
+        url = "https://www.evil.com/subpathABC"
+        expect(Block.new(url)).not_to be_blocked
+      end
+
       it "does not match a parent path" do
         url = "http://www.evil.com"
         expect(Block.new(url)).not_to be_blocked


### PR DESCRIPTION
Our previous code used simple string comparison, which meant that if `evil.com/subpath` was blocked, we would also block everything under `evil.com/subpathABC` (since it starts with `evil.com/subpathABC`).

The fix is to use code that understands that the URLs are actually URLs, not simple strings, so that we can correctly compare the hosts and paths.

This uses `Pathname#ascend` (docs: https://ruby-doc.org/stdlib-2.5.3/libdoc/pathname/rdoc/Pathname.html#method-i-ascend) which yields an iterator over the parent directories of a given Pathname.

For example, given `/foo/bar/baz`, `ascend` yields `/foo/bar/baz`, then `/foo/bar`, then `/foo`, then `/`. The yielded values are Pathnames, not strings.