### PR TITLE
Version all old ActiveRecord migration classes

### DIFF
--- a/db/migrate/20151103053545_create_delayed_jobs.rb
+++ b/db/migrate/20151103053545_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[5.2]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20151110191852_create_redirections.rb
+++ b/db/migrate/20151110191852_create_redirections.rb
@@ -1,4 +1,4 @@
-class CreateRedirections < ActiveRecord::Migration
+class CreateRedirections < ActiveRecord::Migration[5.2]
   def change
     create_table :redirections do |t|
       t.timestamps null: false

--- a/db/migrate/20151111222648_remove_foreign_key.rb
+++ b/db/migrate/20151111222648_remove_foreign_key.rb
@@ -1,4 +1,4 @@
-class RemoveForeignKey < ActiveRecord::Migration
+class RemoveForeignKey < ActiveRecord::Migration[5.2]
   def up
     remove_foreign_key :redirections, column: :next_id
   end

--- a/db/migrate/20151217165101_remove_delayed_jobs.rb
+++ b/db/migrate/20151217165101_remove_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class RemoveDelayedJobs < ActiveRecord::Migration
+class RemoveDelayedJobs < ActiveRecord::Migration[5.2]
   def up
     drop_table :delayed_jobs
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.


### PR DESCRIPTION
Rails 7 will throw an error about unversioned migrations:

    Directly inheriting from ActiveRecord::Migration is not supported.
    Please specify the Active Record release the migration was written
    for.