### PR TITLE
Remove everything about ActionMailer and ActiveJob

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,10 +1,9 @@
 require File.expand_path('../boot', __FILE__)
+
 require "rails"
 require "active_model/railtie"
-require "active_job/railtie"
 require "active_record/railtie"
 require "action_controller/railtie"
-require "action_mailer/railtie"
 require "action_view/railtie"
 
 Bundler.require(*Rails.groups)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,8 +2,6 @@ Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local       = true
-  config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :test
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
@@ -25,8 +23,6 @@ Rails.application.configure do
   config.assets.digest = true
   config.assets.raise_runtime_errors = true
   config.i18n.raise_on_missing_translations = true
-  config.action_mailer.default_url_options = { host: "localhost:3000" }
-  config.action_mailer.perform_caching = false
   config.assets.quiet = true
   config.active_record.verbose_query_logs = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,13 +11,10 @@ Rails.application.configure do
   config.assets.digest = true
   config.log_level = :debug
   config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
-  config.action_mailer.delivery_method = :smtp
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
   config.active_record.dump_schema_after_migration = false
-  config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
-  config.action_mailer.perform_caching = false
   config.log_tags = [:request_id]
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,12 +7,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.action_dispatch.show_exceptions = false
   config.action_controller.allow_forgery_protection = false
-  config.action_mailer.delivery_method = :test
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr
   config.i18n.raise_on_missing_translations = true
-  config.action_mailer.default_url_options = { host: "www.example.com" }
-  config.active_job.queue_adapter = :inline
   config.cache_store = :null_store
-  config.action_mailer.perform_caching = false
 end

--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -19,26 +19,6 @@
 # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
 # Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
 
-# Return false instead of self when enqueuing is aborted from a callback.
-# Rails.application.config.active_job.return_false_on_aborted_enqueue = true
-
-# Send Active Storage analysis and purge jobs to dedicated queues.
-# Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
-# Rails.application.config.active_storage.queues.purge    = :active_storage_purge
-
-# When assigning to a collection of attachments declared via `has_many_attached`, replace existing
-# attachments instead of appending. Use #attach to add new attachments without replacing existing ones.
-# Rails.application.config.active_storage.replace_on_assign_to_many = true
-
-# Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
-#
-# The default delivery jobs (ActionMailer::Parameterized::DeliveryJob, ActionMailer::DeliveryJob),
-# will be removed in Rails 6.1. This setting is not backwards compatible with earlier Rails versions.
-# If you send mail in the background, job workers need to have a copy of
-# MailDeliveryJob to ensure all delivery jobs are processed properly.
-# Make sure your entire app is migrated and stable on 6.0 before using this setting.
-# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
-
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
 # of the relation's cache key into the cache version to support recycling cache key.

--- a/spec/support/action_mailer.rb
+++ b/spec/support/action_mailer.rb
@@ -1,5 +1,0 @@
-RSpec.configure do |config|
-  config.before(:each) do
-    ActionMailer::Base.deliveries.clear
-  end
-end


### PR DESCRIPTION
We can't remove the gems since `rails` pulls them in, but we can avoid loading them in the first place.