### PR TITLE
Update `regexp_parser` gem for Ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    regexp_parser (1.7.0)
+    regexp_parser (1.8.2)
     rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)


### PR DESCRIPTION
We get this warning when running tests otherwise:


> This library has only been tested up to Ruby 2.x, but you are running with Regexp::Syntax::V3_0_3 (feature set of V2_6_3)