### PR TITLE
Make `config.ru` match Rails 7

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require_relative "config/environment"
+
 run Rails.application
+Rails.application.load_server


### PR DESCRIPTION
I don't think the `load_server` change changes anything for the app now, but calling `load_server` ensures we run the Railtie `server` hook, which other gems might use.