### PR TITLE
Redirect to an existing blocked Redirection

### DIFF
--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -58,6 +58,12 @@ class RedirectionsController < ApplicationController
   end
 
   def ensure_referrer_is_not_blocked
+    if Redirection.exists?(slug: params[:slug])
+      # If the redirection already exists, let it through. We just want to
+      # prevent further redirections from being created.
+      return
+    end
+
     if Block.new(referrer).blocked?
       redirect_to Redirection.first.url, allow_other_host: true
     end


### PR DESCRIPTION
If the Redirection is already in the webring, then redirect to it instead of to `Redirection.first`.

This fixes a bug with the Redirection for HLWR itself: we blocked the `"hotlinewebring.club"` URL so that nobody can add it as their own site, but because it's blocked, it doesn't redirect to its own next/previous links.

This change also means that when we block but do not unlink a site, then clicking on its links will redirect to its actual next/previous links instead of `Redirection.first`, which is fine. Blocked sites cannot be added to the ring, but if they're already in, then they work normally.