### PR TITLE
Disable redirection creation

### DIFF
--- a/app/assets/stylesheets/_pages.scss
+++ b/app/assets/stylesheets/_pages.scss
@@ -77,3 +77,13 @@ ul {
   margin: 0;
   padding: 0;
 }
+
+.annoucement {
+  background-color: $dark-pink;
+  color: white;
+  padding: 1em;
+
+  a {
+    color: currentcolor;
+  }
+}

--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -18,7 +18,8 @@ class RedirectionsController < ApplicationController
 
   def find_or_create_redirection
     Redirection.find_by(slug: params[:slug]) ||
-      RedirectionCreation.perform(referrer, params[:slug]) ||
+      # Creation paused for now as we sort out weirdness
+      # RedirectionCreation.perform(referrer, params[:slug]) ||
       log_headers_and_use_fallback_redirection
   end
 

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -43,6 +43,10 @@
     </p>
 
     <h3>How to Join</h3>
+    <section class="annoucement">
+      <p>
+        <strong>Note</strong>: Automatic joining is disabled for the moment while we sort out some issues. Please complete the steps below and then <%= mail_to "webmaster@hotlinewebring.club", "contact us" %> if you'd like to join.</p>
+    </section>
     <p>Here's our easy two-and-a-half-step process:</p>
 
     <ol>

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RedirectionsController do
   [:next, :previous].each do |action|
     describe "GET #{action}" do
       it "creates a Redirection if it doesn't exist" do
+        skip "to try and figure out where so many false sites are coming from"
         new_slug = "new"
         url = "http://example.com"
         first_redirection = Redirection.first
@@ -29,6 +30,7 @@ RSpec.describe RedirectionsController do
       end
 
       it "does not allow creating the exact same URL twice" do
+        skip "to try and figure out where so many false sites are coming from"
         url = "https://unique-website.com"
         new_slug = "new"
         old_slug = "old"
@@ -43,6 +45,7 @@ RSpec.describe RedirectionsController do
       end
 
       it "considers similar URLs to be the same" do
+        skip "to try and figure out where so many false sites are coming from"
         old_url = "https://www.cool.com"
         old_slug = "old"
         new_url = "https://cool.com"

--- a/spec/features/admin_blocks_a_redirection_spec.rb
+++ b/spec/features/admin_blocks_a_redirection_spec.rb
@@ -19,11 +19,12 @@ RSpec.feature "Admin unlinks a redirection" do
       expect(page).not_to have_text(url)
 
       # Now assert that we can re-add this slug and URL
-      page.driver.header('Referer', url)
-      visit "/#{slug}/next"
+      # skipping to try and figure out where so many false sites are coming from
+      # page.driver.header('Referer', url)
+      # visit "/#{slug}/next"
 
-      expect(page).to have_text(url)
-      expect(page).to have_text(slug)
+      # expect(page).to have_text(url)
+      # expect(page).to have_text(slug)
     end
   end
 


### PR DESCRIPTION
We've been getting a lot of sites that aren't valid. Some seem like spam, some seem like bugs, but there are a lot of them. This makes it impossible to join automatically and adds instructions to contact us if a site would like to join.

<img width="841" alt="instructions screen shot" src="https://user-images.githubusercontent.com/49549/167966929-78a777be-f3d1-466b-b671-16ddb41efc32.png">