### PR TITLE
Block search engine crawler bots

### DIFF
--- a/app/assets/stylesheets/_pages.scss
+++ b/app/assets/stylesheets/_pages.scss
@@ -78,7 +78,7 @@ ul {
   padding: 0;
 }
 
-.annoucement {
+.announcement {
   background-color: $dark-pink;
   color: white;
   padding: 1em;

--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -18,8 +18,7 @@ class RedirectionsController < ApplicationController
 
   def find_or_create_redirection
     Redirection.find_by(slug: params[:slug]) ||
-      # Creation paused for now as we sort out weirdness
-      # RedirectionCreation.perform(referrer, params[:slug]) ||
+      RedirectionCreation.perform(referrer, params[:slug]) ||
       log_headers_and_use_fallback_redirection
   end
 

--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -18,8 +18,17 @@ class RedirectionsController < ApplicationController
 
   def find_or_create_redirection
     Redirection.find_by(slug: params[:slug]) ||
-      RedirectionCreation.perform(referrer, params[:slug]) ||
+      create_redirection ||
       log_headers_and_use_fallback_redirection
+
+  end
+
+  def create_redirection
+    if ENV.fetch("DISALLOW_CREATING_NEW_REDIRECTIONS", false)
+      false
+    else
+      RedirectionCreation.perform(referrer, params[:slug])
+    end
   end
 
   def log_headers_and_use_fallback_redirection

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -43,6 +43,13 @@
     </p>
 
     <h3>How to Join</h3>
+    <% if ENV.fetch("DISALLOW_CREATING_NEW_REDIRECTIONS", false) %>
+      <section class="announcement">
+        <p>
+          <strong>Note</strong>: Automatic joining is disabled for the moment while we sort out some issues. Please complete the steps below and then <%= mail_to "webmaster@hotlinewebring.club", "contact us" %> if you'd like to join.
+        </p>
+      </section>
+    <% end %>
     <p>Here's our easy two-and-a-half-step process:</p>
 
     <ol>

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -43,10 +43,6 @@
     </p>
 
     <h3>How to Join</h3>
-    <section class="annoucement">
-      <p>
-        <strong>Note</strong>: Automatic joining is disabled for the moment while we sort out some issues. Please complete the steps below and then <%= mail_to "webmaster@hotlinewebring.club", "contact us" %> if you'd like to join.</p>
-    </section>
     <p>Here's our easy two-and-a-half-step process:</p>
 
     <ol>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+
+User-agent: *
+Disallow: /*/previous
+Disallow: /*/next

--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe RedirectionsController do
   [:next, :previous].each do |action|
     describe "GET #{action}" do
       it "creates a Redirection if it doesn't exist" do
-        skip "to try and figure out where so many false sites are coming from"
         new_slug = "new"
         url = "http://example.com"
         first_redirection = Redirection.first
@@ -30,7 +29,6 @@ RSpec.describe RedirectionsController do
       end
 
       it "does not allow creating the exact same URL twice" do
-        skip "to try and figure out where so many false sites are coming from"
         url = "https://unique-website.com"
         new_slug = "new"
         old_slug = "old"
@@ -45,7 +43,6 @@ RSpec.describe RedirectionsController do
       end
 
       it "considers similar URLs to be the same" do
-        skip "to try and figure out where so many false sites are coming from"
         old_url = "https://www.cool.com"
         old_slug = "old"
         new_url = "https://cool.com"

--- a/spec/features/admin_blocks_a_redirection_spec.rb
+++ b/spec/features/admin_blocks_a_redirection_spec.rb
@@ -19,12 +19,11 @@ RSpec.feature "Admin unlinks a redirection" do
       expect(page).not_to have_text(url)
 
       # Now assert that we can re-add this slug and URL
-      # skipping to try and figure out where so many false sites are coming from
-      # page.driver.header('Referer', url)
-      # visit "/#{slug}/next"
+      page.driver.header('Referer', url)
+      visit "/#{slug}/next"
 
-      # expect(page).to have_text(url)
-      # expect(page).to have_text(slug)
+      expect(page).to have_text(url)
+      expect(page).to have_text(slug)
     end
   end
 


### PR DESCRIPTION
All of the user agents (`HTTP_USER_AGENT`) for the recent flood of spam requests are crawlers:

* Applebot
* SemrushBot
* PetalBot
* DataForSeoBot

Here's an example line from the logs, anonymized:

```
[SLUG_GOES_HERE] {"HTTP_VERSION"=>"HTTP/1.1", "HTTP_HOST"=>"hotlinewebring.club", "HTTP_CONNECTION"=>"close", "HTTP_USER_AGENT"=>"Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)", "HTTP_ACCEPT_ENCODING"=>"gzip, deflate, br", "HTTP_UPGRADE_INSECURE_REQUESTS"=>"1", "HTTP_X_REQUEST_ID"=>"117ec039-a786-4a9a-96f4-464fb6397ba9", "HTTP_X_FORWARDED_FOR"=>"142.132.248.181", "HTTP_X_FORWARDED_PROTO"=>"https", "HTTP_X_FORWARDED_PORT"=>"443", "HTTP_VIA"=>"1.1 vegur", "HTTP_CONNE→
```

My guess is that these crawlers archived the links on people's websites (e.g. `https://hotlinewebring.club/SLUG/next`) a while ago and are now re-crawling them to refresh their indices. We now block them from indexing those URLs (and triggering HLWR to add a long-removed site to the ring) by adding all next/previous URLs to `robots.txt`.