### PR TITLE
Display *original* URL in RSS feed

### DIFF
--- a/app/views/feeds/show.atom.builder
+++ b/app/views/feeds/show.atom.builder
@@ -11,7 +11,8 @@ atom_feed do |feed|
       entry.title "#{redirection.slug} joined Hotline Webring"
       entry.updated redirection.created_at.iso8601
       entry.content redirection.url
-      entry.link redirection.url
+      entry.link redirection.original_url
+      entry.link redirection.url, rel: "alternate"
       entry.author do |author|
         author.name t("authors")
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     sequence(:slug) { |n| "slug#{n}" }
     sequence(:url) { |n| "http://example#{n}.com" }
     next_id { -1 }
-    original_url { url }
+    original_url { "#{url}?original" }
 
     after(:create) do |redirection|
       if redirection.next_id == -1


### PR DESCRIPTION
This will make it easier for us to find the links in Slack.