### PR TITLE
Use <link href=URL> instead of <link>URL</link>


### DIFF
--- a/app/views/feeds/show.atom.builder
+++ b/app/views/feeds/show.atom.builder
@@ -11,8 +11,8 @@ atom_feed do |feed|
       entry.title "#{redirection.slug} joined Hotline Webring"
       entry.updated redirection.created_at.iso8601
       entry.content redirection.url
-      entry.link redirection.original_url
-      entry.link redirection.url, rel: "alternate"
+      entry.link href: redirection.original_url
+      entry.link href: redirection.url, rel: "alternate"
       entry.author do |author|
         author.name t("authors")
       end

--- a/spec/requests/feed_requests_spec.rb
+++ b/spec/requests/feed_requests_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Feed requests" do
 
       expect(text_of("title")).to eq(title)
       expect(text_of("content")).to eq(content)
-      expect(text_of("link:not([rel])")).to eq(redirection.original_url)
-      expect(text_of("link[rel=alternate]")).to eq(redirection.url)
+      expect(entry_css("link:not([rel])")[:href]).to eq(redirection.original_url)
+      expect(entry_css("link[rel=alternate]")[:href]).to eq(redirection.url)
       expect(text_of("author > name")).to eq("Gabe and Edward")
       expect(text_of("id")).to eq(id)
       expect(text_of("updated")).to eq(updated)
@@ -61,6 +61,10 @@ RSpec.describe "Feed requests" do
   end
 
   def text_of(selector)
-    first_entry.css(selector).text
+    entry_css(selector).text
+  end
+
+  def entry_css(selector)
+    first_entry.css(selector).first
   end
 end


### PR DESCRIPTION
Slack's customer support says that our malformed `<link>`s are why we get the weird empty parentheses in Slack like this:

```
[slug] joined Hotline Webring ()
```

Hopefully this will fix it!