### PR TITLE
Block subdomains of an existing redirection


### DIFF
--- a/spec/controllers/redirections_controller_spec.rb
+++ b/spec/controllers/redirections_controller_spec.rb
@@ -124,6 +124,18 @@ RSpec.describe RedirectionsController do
           expect(Redirection.where(slug: new_slug)).to be_empty
         end
       end
+
+      context "when the is for a subdomain of an existing site" do
+        it "does not create a new redirection" do
+          expect(Redirection.find_by(url: "http://gabebw.com")).to be_present
+          new_slug = "new"
+
+          request.env["HTTP_REFERER"] = "https://www2.gabebw.com/bruh12"
+          get action, params: { slug: new_slug }
+
+          expect(Redirection.where(slug: new_slug)).to be_empty
+        end
+      end
     end
   end
 


### PR DESCRIPTION

If we already have `foo.com`, we now block `bar.foo.com` from joining. Unfortunately we have to do `Redirection.all.find` to do this check. It's not great, but it's probably not that bad in practice since we don't have thousands of Redirections.

If we could add arbitrary extensions to Postgres, I'd do it inside Postgres with https://github.com/petere/pguri and compare `uri_host` plus some string manipulation, but we can't do that.
