### PR TITLE
Block IP address range 10.0.0.0/8


### DIFF
--- a/app/models/host_validator.rb
+++ b/app/models/host_validator.rb
@@ -4,6 +4,7 @@ class HostValidator
   # https://en.wikipedia.org/wiki/Reserved_IP_addresses
   INVALID_IP_RANGES = %w(
     0.0.0.0/8
+    10.0.0.0/8
     127.0.0.0/8
     192.168.0.0/16
   ).map { |address| IPAddr.new(address) }

--- a/spec/models/host_validator_spec.rb
+++ b/spec/models/host_validator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe HostValidator do
       http://0.0.0.0:8000
       http://127.0.0.1:3000
       http://192.168.1.0
+      http://10.101.145.9/
     ).each do |ignored|
       it "returns true for #{ignored}" do
         host_validator = HostValidator.new(ignored)


### PR DESCRIPTION

We just had someone (accidentally) join with http://10.101.145.9/ .

Now they can't do that.