### PR TITLE
Unlink sites that fail `drake link_audit`

### DIFF
--- a/lib/tasks/link-audit.rake
+++ b/lib/tasks/link-audit.rake
@@ -13,14 +13,19 @@ task link_audit: :environment do
 
     if result[:status] == :good
       green("#{redirection.url} is all good")
-    elsif result[:status] == :offline
-      red("#{redirection.url} is no longer online at all")
-    elsif result[:status] == :not_found
-      red("#{redirection.url} is a 404")
-    elsif result[:status] == :error
-      red("#{redirection.url} error: #{result[:error]} ")
-    elsif result[:status] == :missing_links
-      red("#{redirection.url} is missing #{result[:missing].join(' and ')}")
+    else
+      # Something went wrong: unlink it no matter what the issue was.
+      redirection.unlink
+
+      if result[:status] == :offline
+        red("#{redirection.url} is no longer online at all")
+      elsif result[:status] == :not_found
+        red("#{redirection.url} is a 404")
+      elsif result[:status] == :error
+        red("#{redirection.url} error: #{result[:error]} ")
+      elsif result[:status] == :missing_links
+        red("#{redirection.url} is missing #{result[:missing].join(" and ")}")
+      end
     end
   end
 end


### PR DESCRIPTION
We have a lot of sites, and some of them are not really "in" the webring any more:

* the site is no longer online
* the site is online but has an SSL certificate error
* the `next` and/or `previous` links to other HLWR sites are missing
* and so on.

We can't keep up with every single possible error, but we also want to keep the webring as a connected ring of valid sites. When one of the sites in the ring is invalid, it breaks the ring.

So let's do the easiest thing possible: if `rake link_audit` detects any error at all, it removes that site from the webring (**without blocking them**). If someone wants to rejoin, they can do so very easily.

https://github.com/hotline-webring/hotline-webring/issues/385