### PR TITLE
Add API endpoints for our slack bot


### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,6 +1,7 @@
 # http://ddollar.github.com/foreman/
 ADMIN_PASSWORD=admin
 ADMIN_USERNAME=admin
+API_TOKEN=my-cool-api-token
 APPLICATION_HOST=localhost:3000
 ASSET_HOST=localhost:3000
 EXECJS_RUNTIME=Node

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ To allow creating new redirections again, unset the variable:
 
     production config:unset DISALLOW_CREATING_NEW_REDIRECTIONS
 
+## API
+
+We have an API, oddly enough. It's used by our Slack bot, and we don't expect
+(or allow) anyone else to use it.
+
 ## Guidelines
 
 Use the following guides for getting things done, programming well, and

--- a/app/controllers/admin/blocks_controller.rb
+++ b/app/controllers/admin/blocks_controller.rb
@@ -1,9 +1,9 @@
 class Admin::BlocksController < AdminController
   def create
     redirection = Redirection.find(params[:redirection_id])
-    blocked_referrer = BlockedReferrer.new_from_url(redirection.url)
+    blocked_referrer = BlockedReferrer.block_and_unlink(redirection)
 
-    if blocked_referrer.save && redirection.unlink
+    if blocked_referrer
       flash[:success] = "Blocked and unlinked #{blocked_referrer.host_with_path}"
       redirect_to admin_redirections_path
     else

--- a/app/controllers/api/blocks_controller.rb
+++ b/app/controllers/api/blocks_controller.rb
@@ -1,0 +1,11 @@
+class Api::BlocksController < ApiController
+  def create
+    redirection = Redirection.find_by!(slug: params[:redirection_slug])
+
+    if BlockedReferrer.block_and_unlink(redirection)
+      render json: { success: true }, status: 201
+    else
+      render json: { success: false }, status: 500
+    end
+  end
+end

--- a/app/controllers/api/unlinks_controller.rb
+++ b/app/controllers/api/unlinks_controller.rb
@@ -1,0 +1,11 @@
+class Api::UnlinksController < ApiController
+  def create
+    redirection = Redirection.find_by!(slug: params[:redirection_slug])
+
+    if redirection.unlink
+      render json: { success: true }, status: 201
+    else
+      render json: { success: false }, status: 500
+    end
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,16 @@
+class ApiController < ApplicationController
+  API_TOKEN = ENV.fetch("API_TOKEN")
+
+  protect_from_forgery with: :null_session
+  before_action :authenticate
+
+  private
+
+  def authenticate
+    authenticate_or_request_with_http_token do |token, options|
+      # Compare the tokens in a time-constant manner, to mitigate
+      # timing attacks.
+      ActiveSupport::SecurityUtils.secure_compare(token, API_TOKEN)
+    end
+  end
+end

--- a/app/models/blocked_referrer.rb
+++ b/app/models/blocked_referrer.rb
@@ -8,7 +8,7 @@ class BlockedReferrer < ActiveRecord::Base
   #
   # Otherwise, it simply uses the site's host.
   def self.new_from_url(url)
-    uri =  URI.parse(url)
+    uri = URI.parse(url)
 
     if uri.host == "sites.google.com" && uri.path.start_with?("/site/")
       site_name = uri.path.split("/")[2]
@@ -18,5 +18,14 @@ class BlockedReferrer < ActiveRecord::Base
     end
 
     new(host_with_path: host_with_path)
+  end
+
+  def self.block_and_unlink(redirection)
+    blocked_referrer = new_from_url(redirection.url)
+    transaction do
+      blocked_referrer.save!
+      redirection.unlink
+      blocked_referrer
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,15 @@ Rails.application.routes.draw do
     root "redirections#index"
   end
 
+  namespace :api do
+    # We use the *slug* as the redirection ID because the Slack bot (this
+    # API's only user) can only get the slug right now.
+    resources :redirections, only: [], param: :slug do
+      resources :blocks, only: [:create]
+      resources :unlinks, only: [:create]
+    end
+  end
+
   get "feed", to: "feeds#show", defaults: { format: :atom }
   get ":slug/next", to: "redirections#next"
   get ":slug/previous", to: "redirections#previous"

--- a/spec/models/blocked_referrer_spec.rb
+++ b/spec/models/blocked_referrer_spec.rb
@@ -24,4 +24,31 @@ RSpec.describe BlockedReferrer do
       expect(blocked_referrer.host_with_path).to eq("example.com")
     end
   end
+
+  describe ".block_and_unlink" do
+    it "blocks the site" do
+      redirection = create(:redirection, url: "https://foobar.neocities.org/anything/else")
+
+      BlockedReferrer.block_and_unlink(redirection)
+
+      blocked_referrer = BlockedReferrer.last
+      expect(blocked_referrer.host_with_path).to eq("foobar.neocities.org")
+    end
+
+    it "unlinks the redirection" do
+      redirection = create(:redirection, url: "https://foobar.neocities.org/anything/else")
+
+      BlockedReferrer.block_and_unlink(redirection)
+
+      expect(Redirection.find_by(slug: redirection.slug)).to be_nil
+    end
+
+    it "returns the BlockedReferrer" do
+      redirection = create(:redirection, url: "https://foobar.neocities.org/anything/else")
+
+      result = BlockedReferrer.block_and_unlink(redirection)
+
+      expect(result).to eq(BlockedReferrer.last)
+    end
+  end
 end

--- a/spec/requests/api_blocks_requests_spec.rb
+++ b/spec/requests/api_blocks_requests_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "API block requests" do
+  describe "Creating" do
+    context "if API token is incorrect" do
+      it "returns a 401 status code" do
+        redirection = Redirection.find_by!(slug: "gabe")
+
+        post api_redirection_blocks_path(redirection.slug)
+
+        expect(response.status).to eq 401
+        expect(Redirection.find_by(slug: redirection.slug)).not_to be_nil
+        expect(BlockedReferrer.count).to eq 0
+      end
+    end
+
+    it "unlinks the redirection" do
+      redirection = create(:redirection, url: "https://foobar.neocities.org")
+
+      post api_redirection_blocks_path(redirection.slug),
+           headers: {
+             Authorization: "Bearer #{ApiController::API_TOKEN}",
+           }
+
+      expect(response.status).to eq 201
+      expect(JSON.parse(response.body)["success"]).to eq true
+      expect(Redirection.find_by(slug: redirection.slug)).to be_nil
+    end
+
+    it "blocks the redirection" do
+      redirection = create(:redirection, url: "https://foobar.neocities.org")
+
+      post api_redirection_blocks_path(redirection.slug),
+           headers: {
+             Authorization: "Bearer #{ApiController::API_TOKEN}",
+           }
+
+      expect(BlockedReferrer.last.host_with_path).to eq("foobar.neocities.org")
+    end
+  end
+end

--- a/spec/requests/api_unlinks_requests_spec.rb
+++ b/spec/requests/api_unlinks_requests_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "API unlink requests" do
+  describe "Creating" do
+    context "if API token is incorrect" do
+      it "returns a 401 status code" do
+        redirection = Redirection.find_by!(slug: "gabe")
+
+        post api_redirection_unlinks_path(redirection.slug)
+
+        expect(response.status).to eq 401
+        expect(Redirection.find_by(slug: redirection.slug)).not_to be_nil
+        expect(BlockedReferrer.count).to eq 0
+      end
+    end
+
+    it "unlinks the redirection" do
+      redirection = create(:redirection, url: "https://foobar.neocities.org")
+
+      post api_redirection_unlinks_path(redirection.slug),
+           headers: {
+             Authorization: "Bearer #{ApiController::API_TOKEN}",
+           }
+
+      expect(response.status).to eq 201
+      expect(JSON.parse(response.body)["success"]).to eq true
+      expect(Redirection.find_by(slug: redirection.slug)).to be_nil
+    end
+
+    it "does not block the redirection" do
+      redirection = create(:redirection, url: "https://foobar.neocities.org")
+
+      post api_redirection_unlinks_path(redirection.slug),
+           headers: {
+             Authorization: "Bearer #{ApiController::API_TOKEN}",
+           }
+
+      expect(BlockedReferrer.count).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
The endpoints are:

```
POST  /api/redirections/:redirection_slug/blocks
POST  /api/redirections/:redirection_slug/unlinks
```

We use the slug because the Slack bot can only figure out the slug from the messages it sees in Slack. The slug is unique, so it shouldn't be an issue.

To see how the Slack bot works, see the (private) repo https://github.com/hotline-webring/sauron