### PR TITLE
Upgrade heroku-deploy GitHub Action


### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy to Heroku staging
-        uses: akhileshns/heroku-deploy@v3.12.12
+        uses: akhileshns/heroku-deploy@v3.12.13
 
         # `types: [closed]` above means that this step runs even when a PR is
         # closed without merging.


### PR DESCRIPTION

This fixes a deprecation warning about using Node 12, by using Node 16 instead.

Release notes: https://github.com/AkhileshNS/heroku-deploy/releases/tag/v3.12.13