### PR TITLE
Fix Heroku deploy action (hopefully)


### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: ${{ secrets.HEROKU_STAGING_APP_NAME }}
+          heroku_app_name: hotline-webring-staging
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           dontuseforce: true
           dontautocreate: true
@@ -39,7 +39,7 @@ jobs:
         if: ${{ github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true }}
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: ${{ secrets.HEROKU_PRODUCTION_APP_NAME }}
+          heroku_app_name: hotline-webring-production
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           dontuseforce: true
           dontautocreate: true

--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Deploy to Heroku staging
         uses: akhileshns/heroku-deploy@v3.12.13


### PR DESCRIPTION

This PR changes the code to pass the Heroku app name in plain text.

For some reason, the action can't find the secrets. To fix it, just pass them in plain text. This is the error we were getting:

> Error: Command failed: heroku git:remote --app
> Error: Flag --app expects a value

This indicates that the `heroku_app_name` value is blank for some reason.

You can see it on https://github.com/hotline-webring/hotline-webring/actions/runs/4440720997

---------

This also, less importantly, updates us to actions/checkout v3.

This fixes a warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2.
> For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

You can see this error on e.g.  https://github.com/hotline-webring/hotline-webring/actions/runs/4440720997
