### PR TITLE
Remove (most) references to heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ Set up the repo:
 
 Run the app using [Heroku Local]:
 
-    $ heroku local
-
-[Heroku Local]: https://devcenter.heroku.com/articles/heroku-local
+    $ rails s
 
 Run the specs:
 

--- a/bin/setup
+++ b/bin/setup
@@ -23,13 +23,4 @@ if [ -z "$CI" ]; then
 
   # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
   mkdir -p .git/safe
-
-  if ! command -v heroku > /dev/null; then
-    echo "!! Please install the Heroku CLI: "
-    echo "!!  https://devcenter.heroku.com/articles/heroku-cli#download-and-install"
-    exit 1
-  fi
-
-  heroku git:remote --remote staging --app hotline-webring-staging || true
-  heroku git:remote --remote production --app hotline-webring-production || true
 fi

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,9 +1,5 @@
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
-# The environment variable WEB_CONCURRENCY may be set to a default value based
-# on dyno size. To manually configure this value use heroku config:set
-# WEB_CONCURRENCY.
-#
 # Increasing the number of workers will increase the amount of resting memory
 # your dynos use. Increasing the number of threads will increase the amount of
 # potential bloat added to your dynos when they are responding to heavy
@@ -20,12 +16,6 @@ preload_app!
 
 rackup DefaultRackup
 environment ENV.fetch("RACK_ENV", "development")
-
-on_worker_boot do
-  # Worker specific setup for Rails 4.1+
-  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
-  ActiveRecord::Base.establish_connection
-end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
We don't use heroku anymore. One of the references referenced rails 4.1. I figured it was safe to delete. There's also some references in the README and in `config/puma.rb`. I'm not sure what the equivalents are with fly.io though so I left em.

Please appreciate the branch name.