### PR TITLE
Update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,4 +316,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   2.3.7
+   2.4.13


### PR DESCRIPTION
Without this, I was getting an error `uninitialized constant Gem::Source`. This thread suggested I update bundler and it totally fixed it:

https://github.com/rubygems/rubygems/issues/5351#issuecomment-1143599660