### PR TITLE
Do not encourage people to join in the `<meta>` description if it's closed

### DIFF
--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -52,7 +52,7 @@
     </p>
 
     <h3>How to Join</h3>
-    <% if ENV.fetch("DISALLOW_CREATING_NEW_REDIRECTIONS", false) %>
+    <% if Rails.configuration.disallow_creating_new_redirections %>
       <section class="announcement">
         <p>
           <strong>Note</strong>: Automatic joining is disabled for the moment while we sort out some issues. Please complete the steps below and then <%= email_us %> if you'd like to join.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,11 @@
   <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />
   <meta property="og:title" content="Hotline Webring" />
-  <meta property="og:description" content="A friendly ring of cool websites. Join today!" />
+  <% if Rails.configuration.closed %>
+    <meta property="og:description" content="A friendly ring of cool websites." />
+  <% else %>
+    <meta property="og:description" content="A friendly ring of cool websites. Join today!" />
+  <% end %>
   <meta name="twitter:card" value="summary" />
   <meta name="twitter:image" value="<%= image_url("hlwr-square-black.png") %>"/>
   <title>Hotline Webring</title>


### PR DESCRIPTION
The meta description shows up in e.g. Slack unfurls.