### PR TITLE
Fix Heroku Deploy action


### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Deploy to Heroku staging
         uses: akhileshns/heroku-deploy@v3.12.14
 


### PR DESCRIPTION

This change is based on the docs here: https://github.com/marketplace/actions/deploy-to-heroku

You can see a failing GitHub Actions run here: https://github.com/hotline-webring/hotline-webring/actions/runs/14046938336/job/39329693451
