### PR TITLE
Add "Last seen" column to admin interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ end
 group :test do
   gem "capybara", "~> 3.0"
   gem "launchy"
+  gem "orderly"
   gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,9 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     normalize-rails (3.0.3)
+    orderly (0.1.1)
+      capybara (>= 1.1)
+      rspec (>= 2.14)
     pg (1.5.9)
     pp (0.6.2)
       prettyprint
@@ -251,6 +254,10 @@ GEM
     reline (0.6.0)
       io-console (~> 0.5)
     rexml (3.3.9)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -341,6 +348,7 @@ DEPENDENCIES
   high_voltage
   launchy
   normalize-rails (~> 3.0.0)
+  orderly
   pg
   pry-rails
   puma (~> 5.6)

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -18,15 +18,19 @@ main {
   max-width: $admin-max-width;
 }
 
+main > section {
+  margin-bottom: 2em;
+}
+
+h2 {
+  font-size: 1.3em;
+}
+
 .redirection {
-  border-bottom: 1px solid black;
-  display: flex;
-  flex-direction: column;
-  justify-items: center;
   margin-bottom: 1em;
 
   > div {
-    margin-bottom: 1rem;
+    padding-bottom: 1rem;
     display: grid;
     grid-template-columns: 1fr 3fr;
     column-gap: 1em;
@@ -78,7 +82,7 @@ main {
 // Must be at the bottom, but before the media query, so it overrides any
 // other `display` property above
 .header-row,
-.original-url {
+.redirection .original-url {
   display: none;
 }
 
@@ -113,22 +117,27 @@ main {
 // Must be at the very bottom
 @media screen and (min-width: 800px) {
   // Wider screens (not a phone)
+  .redirections {
+    display: grid;
+    grid-template-columns:
+      1fr // Slug
+      3fr // URL
+      3fr // Original URL
+      2fr // Last seen
+      1fr // edit
+      repeat(2, 2fr); // buttons
+    column-gap: 1em;
+    row-gap: 1em;
+  }
+
+  .header-row,
+  .redirection {
+    display: contents;
+  }
 
   .redirection {
-    align-items: center;
-    display: grid;
-    justify-items: start;
-    padding: 1rem 0;
-
-    // Everything is `1fr` except for the 2 URL columns, which are wider
-    grid-template-columns:
-    1fr // slug
-    3fr // URL
-    3fr // Original URL
-    repeat(3, 1fr); // Various buttons
-    column-gap: 1em;
-
     > div {
+      border-bottom: 1px solid lightgray;
       display: block;
       margin-bottom: 0;
     }
@@ -138,8 +147,11 @@ main {
     }
   }
 
-  .header-row {
+  .redirection .original-url {
     display: block;
+  }
+
+  .header-row {
     font-weight: bold;
   }
 }

--- a/app/controllers/admin/redirections_controller.rb
+++ b/app/controllers/admin/redirections_controller.rb
@@ -1,6 +1,11 @@
 class Admin::RedirectionsController < AdminController
+  DEFAULT_SORT_PARAMS = {"sort_key" => "next_id", "sort_dir" => "desc"}
+
   def index
-    @redirections = Redirection.order(created_at: :desc)
+    sort_by = DEFAULT_SORT_PARAMS.merge(sort_params)
+    order_by = { sort_by["sort_key"] => sort_by["sort_dir"] }
+
+    @redirections = Redirection.order(order_by)
   end
 
   def edit
@@ -23,5 +28,9 @@ class Admin::RedirectionsController < AdminController
 
   def redirection_params
     params.require(:redirection).permit(:url)
+  end
+
+  def sort_params
+    params.permit(:sort_key, :sort_dir)
   end
 end

--- a/app/controllers/admin/redirections_controller.rb
+++ b/app/controllers/admin/redirections_controller.rb
@@ -3,9 +3,7 @@ class Admin::RedirectionsController < AdminController
 
   def index
     sort_by = DEFAULT_SORT_PARAMS.merge(sort_params)
-    order_by = { sort_by["sort_key"] => sort_by["sort_dir"] }
-
-    @redirections = Redirection.order(order_by)
+    @redirections = Redirection.order_nulls_last(sort_by)
   end
 
   def edit

--- a/app/controllers/redirections_controller.rb
+++ b/app/controllers/redirections_controller.rb
@@ -21,7 +21,9 @@ class RedirectionsController < ApplicationController
 
   def find_or_create_redirection
     if existing_redirection
-      existing_redirection
+      existing_redirection.tap do |redirection|
+        redirection.touch(:last_seen_at)
+      end
     else
       # Always log headers when possibly creating a new Redirection.
       # This ensures that if something goes wonky, we can look back through the

--- a/app/models/redirection.rb
+++ b/app/models/redirection.rb
@@ -9,6 +9,10 @@ class Redirection < ActiveRecord::Base
 
   scope :in_ring_order, -> { order(next_id: :desc) }
   scope :latest_first, -> { order(created_at: :desc) }
+  scope :order_nulls_last, ->(args) do
+    sql = %[#{args["sort_key"]} #{args["sort_dir"]} NULLS LAST]
+    order(sanitize_sql_for_order(Arel.sql(sql)))
+  end
 
   def self.most_recent
     latest_first.first

--- a/app/views/admin/redirections/index.html.erb
+++ b/app/views/admin/redirections/index.html.erb
@@ -1,36 +1,62 @@
-<div class="header-row">
-  <div class="redirection">
-    <div>Slug</div>
-    <div class="url">URL</div>
-    <div class="original-url">Original URL</div>
-    <div class="edit"></div>
-    <div class="block-button"></div>
-    <div class="unlink-button"></div>
-  </div>
-</div>
+<h2>Sort by</h2>
+<section class="sort">
+  <%= link_to(
+    "Ring order",
+    admin_redirections_path(sort_key: "next_id", sort_dir: "desc")
+  ) %>
+  <%= link_to(
+    "Most recently seen",
+    admin_redirections_path(sort_key: "last_seen_at", sort_dir: "desc")
+  ) %>
+  <%= link_to(
+    "Least recently seen",
+    admin_redirections_path(sort_key: "last_seen_at", sort_dir: "asc")
+  ) %>
+</section>
 
-<% @redirections.each do |redirection| %>
-  <div class="redirection" data-id="<%= redirection.id %>">
-    <div>
-      <label>Slug</label>
-      <span class="content"><%= redirection.slug %></span>
-    </div>
-    <div class="url">
-      <label>URL</label>
-      <span class="content"><%= link_to redirection.url, redirection.url %></span>
-    </div>
-    <div class="original-url">
-      <label>Original URL</label>
-      <%= link_to redirection.original_url, redirection.original_url %>
-    </div>
-    <div class="edit">
-      <%= link_to "Edit", edit_admin_redirection_path(redirection) %>
-    </div>
-    <div class="block-button">
-      <%= button_to "Block and unlink", admin_redirection_blocks_path(redirection) %>
-    </div>
-    <div class="unlink-button">
-      <%= button_to "Unlink", admin_redirection_unlinks_path(redirection) %>
+<h2>Redirections</h2>
+<section class="redirections">
+  <div class="header-row">
+    <div class="redirection">
+      <div>Slug</div>
+      <div>URL</div>
+      <div>Original URL</div>
+      <div>Last seen</div>
+      <div></div>
+      <div></div>
+      <div></div>
     </div>
   </div>
-<% end %>
+
+  <% @redirections.each do |redirection| %>
+    <div class="redirection" data-id="<%= redirection.id %>">
+      <div class="slug">
+        <label>Slug</label>
+        <span class="content"><%= redirection.slug %></span>
+      </div>
+      <div class="url">
+        <label>URL</label>
+        <span class="content"><%= link_to redirection.url, redirection.url %></span>
+      </div>
+      <div class="original-url">
+        <label>Original URL</label>
+        <%= link_to redirection.original_url, redirection.original_url %>
+      </div>
+      <div class="last-seen">
+        <label>Last seen</label>
+        <%= time_ago_in_words(
+          redirection.last_seen_at || redirection.created_at
+        ) %>
+      </div>
+      <div class="edit">
+        <%= link_to "Edit", edit_admin_redirection_path(redirection) %>
+      </div>
+      <div class="block-button">
+        <%= button_to "Block and unlink", admin_redirection_blocks_path(redirection) %>
+      </div>
+      <div class="unlink-button">
+        <%= button_to "Unlink", admin_redirection_unlinks_path(redirection) %>
+      </div>
+    </div>
+  <% end %>
+</section>

--- a/db/migrate/20250627212857_add_last_seen_to_redirections.rb
+++ b/db/migrate/20250627212857_add_last_seen_to_redirections.rb
@@ -1,0 +1,5 @@
+class AddLastSeenToRedirections < ActiveRecord::Migration[8.0]
+  def change
+    add_column :redirections, :last_seen_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_03_012614) do
-
+ActiveRecord::Schema[8.0].define(version: 2025_06_27_212857) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "blocked_referrers", force: :cascade do |t|
     t.string "host_with_path", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["host_with_path"], name: "index_blocked_referrers_on_host_with_path", unique: true
   end
 
@@ -29,9 +28,9 @@ ActiveRecord::Schema.define(version: 2020_07_03_012614) do
     t.string "slug", null: false
     t.text "url", null: false
     t.text "original_url", null: false
+    t.datetime "last_seen_at"
     t.index ["next_id"], name: "index_redirections_on_next_id", unique: true
     t.index ["slug"], name: "index_redirections_on_slug", unique: true
     t.index ["url"], name: "index_redirections_on_url", unique: true
   end
-
 end

--- a/spec/features/admin_views_redirections_spec.rb
+++ b/spec/features/admin_views_redirections_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.feature "Admin views redirections" do
-  scenario "cannot get in if they do not know the username or password" do
+RSpec.describe "Admin views redirections" do
+  it "cannot get in if they do not know the username or password" do
     admin_login(admin_wrong_username, admin_wrong_password)
     visit admin_root_path
 
@@ -9,7 +9,7 @@ RSpec.feature "Admin views redirections" do
     expect(page).to have_text("Access denied")
   end
 
-  scenario "sees list of redirections" do
+  it "sees list of redirections" do
     admin_login
     visit admin_root_path
 
@@ -18,5 +18,33 @@ RSpec.feature "Admin views redirections" do
       expect(page).to have_text(redirection.url)
       expect(page).to have_text(redirection.original_url)
     end
+  end
+
+  it "sorts them by name or last seen" do
+    cool = create(:redirection, slug: "cool", last_seen_at: 1.year.ago)
+    neat = create(:redirection, slug: "neat", last_seen_at: 1.month.ago)
+    cool.update(next: neat)
+    neat.update(next: cool)
+
+    admin_login
+    visit admin_root_path
+
+    cool_node = find(".redirection", text: "cool")
+    # default order is next_id in descending order
+    expect(redirection_node("neat")).to appear_before(redirection_node("cool"))
+
+    visit "/cool/next"
+    visit admin_root_path
+    click_on("Most recently seen")
+
+    expect(redirection_node("cool")).to appear_before(redirection_node("neat"))
+
+    click_on("Least recently seen")
+
+    expect(redirection_node("neat")).to appear_before(redirection_node("cool"))
+  end
+
+  def redirection_node(slug)
+    find(".redirection", text: slug)
   end
 end

--- a/spec/features/user_visits_a_redirection_link_spec.rb
+++ b/spec/features/user_visits_a_redirection_link_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "user visits redirection" do
+  it "updates the 'Last seen' column" do
+    redirection = travel_to 1.year.ago do
+      create(:redirection, slug: "hello")
+    end
+
+    admin_login
+    visit admin_root_path
+
+    node = find(".redirection[data-id='#{redirection.id}']")
+    within(node) do
+      expect(page).to have_selector(".slug", text: "hello")
+      expect(page).to have_selector(".last-seen", text: "about 1 year")
+    end
+
+    visit "/hello/next"
+    visit admin_root_path
+
+    node = find(".redirection[data-id='#{redirection.id}']")
+    within(node) do
+      expect(page).to have_selector(".slug", text: "hello")
+      expect(page).to have_selector(".last-seen", text: "less than a minute")
+    end
+  end
+end

--- a/spec/models/redirection_spec.rb
+++ b/spec/models/redirection_spec.rb
@@ -97,6 +97,25 @@ RSpec.describe Redirection do
     end
   end
 
+  describe ".order_nulls_last" do
+    it "ensures null columns are always last" do
+      recently = create(:redirection, last_seen_at: 1.day.ago)
+      a_while_ago = create(:redirection, last_seen_at: 10.days.ago)
+      never = create(:redirection, last_seen_at: nil)
+      set = Redirection.where(id: [recently, a_while_ago, never])
+
+      last_seen_desc = set.order_nulls_last(
+        {"sort_key" => "last_seen_at", "sort_dir" => "desc"}
+      )
+      last_seen_asc = set.order_nulls_last(
+        {"sort_key" => "last_seen_at", "sort_dir" => "asc"}
+      )
+
+      expect(last_seen_desc).to eq([recently, a_while_ago, never])
+      expect(last_seen_asc).to eq([a_while_ago, recently, never])
+    end
+  end
+
   describe "#next_url" do
     it "returns the url of the next referenced redirection" do
       first = Redirection.first

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
     Rails.application.load_seed
   end
   config.include Features, type: :feature
+  config.include ActiveSupport::Testing::TimeHelpers, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true


### PR DESCRIPTION
In order to help track sites that have gone defunct, we can track the last time they were "seen" by updating a `last_seen_at` column every time someone clicks their next or previous link.

![Waterfox](https://github.com/user-attachments/assets/f39da117-a373-4275-a23f-e6633ca7e48a)

I also updated the admin interface to actually be a grid instead of each line being it's own grid. Now all the columns line up.