### PR TITLE
Add release phase for heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -p $PORT -C ./config/puma.rb
+release: bundle exec rails db:migrate


### PR DESCRIPTION
When I deployed a471a5a, I expected the app to automatically migrate. But heroku doesn't do that unless you make a [release phase]. Since this took the admin page down for a good 5m, I'd like to encode this so I don't have to remember again.

[release phase]: https://devcenter.heroku.com/articles/release-phase