### PR TITLE
Allow people to use /prev in addition to /previous

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get "feed", to: "feeds#show", defaults: { format: :atom }
   get ":slug/next", to: "redirections#next"
   get ":slug/previous", to: "redirections#previous"
+  get ":slug/prev", to: "redirections#previous"
   resources :existing_slugs, only: :show
 
   root "homes#show"

--- a/spec/routing/redirection_routing_spec.rb
+++ b/spec/routing/redirection_routing_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Redirection request" do
+  it "allows for both /previous and /prev" do
+    expect(get("/something/previous")).to route_to(
+      controller: "redirections",
+      action: "previous",
+      slug: "something"
+    )
+    expect(get("/something/prev")).to route_to(
+      controller: "redirections",
+      action: "previous",
+      slug: "something"
+    )
+  end
+end


### PR DESCRIPTION
A lot of people do this anyway, so instead of trying to track them down and ask them to correct it, or wait for them to figure it out, it's just nicer to let it ride.