### PR TITLE
Allow updating a redirection's slug

### DIFF
--- a/app/models/redirection.rb
+++ b/app/models/redirection.rb
@@ -47,7 +47,7 @@ class Redirection < ActiveRecord::Base
   def unique_url_with_normalized_urls
     if url.present?
       uri = URI.parse(url)
-      matching_redirection = Redirection.where.not(slug: slug).all.detect do |redirection|
+      matching_redirection = Redirection.excluding(self).find do |redirection|
         UriComparison.same_normalized_uri?(uri, URI.parse(redirection.url))
       end
       if matching_redirection

--- a/spec/models/redirection_spec.rb
+++ b/spec/models/redirection_spec.rb
@@ -66,6 +66,13 @@ RSpec.describe Redirection do
         "is already taken by #{old_slug}"
       )
     end
+
+    it "ignores self when validating slug uniqueness" do
+      redirection = create(:redirection, slug: "funky")
+      redirection.update(slug: "monkey")
+
+      expect(redirection.errors).to be_empty
+    end
   end
 
   describe ".in_ring_order" do


### PR DESCRIPTION
We have a validation that ensures no two redirections have the same normalized URI. It loops through every redirection and checks that the normalized URL isn't the same as the redirection being validated. If it finds a match, the validation fails because that URL already exists on the 'ring.

To prevent the redirection from comparing against itself, we used to filter using `.where.not(slug: slug)`. This works great for new redirections, and for updating most attributes of a redirection. But if you're updating a _slug_, it fails because the updated redirection already has a new slug so `.where.not(slug: slug)` will not exclude it. So I switched it to a `.excluding(self)` which ensures no matter what the properties of the redirection are, it will not check against itself.